### PR TITLE
Update installation.rst to set LOGIN_URL

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -85,6 +85,10 @@ Start by making the following changes to your ``settings.py`` file.
    AUTHENTICATION_BACKENDS = (
        'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
        # ...
+       
+   # Configure django's login_required decorator
+   # to use mozilla-django-keycloak's login URL
+   LOGIN_URL = 'oidc_authentication_init'
    )
 
 You also need to configure some OpenID Connect related settings too.


### PR DESCRIPTION
Update docs to set LOGIN_URL, which enables django's login_required decorator to use mozilla-django-keycloak's login URL.